### PR TITLE
Support SHAMap version 2 (RIPD-1348)

### DIFF
--- a/src/hashprefixes.js
+++ b/src/hashprefixes.js
@@ -19,6 +19,8 @@ exports.HASH_TX_ID = 0x54584E00; // 'TXN'
 exports.HASH_TX_NODE = 0x534E4400; // 'TND'
 // inner node in tree
 exports.HASH_INNER_NODE = 0x4D494E00; // 'MIN'
+// inner node version 2
+exports.HASH_INNER_NODE_V2 = 0x494E5200; // 'INR'
 // leaf node in tree
 exports.HASH_LEAF_NODE = 0x4D4C4E00; // 'MLN'
 // inner transaction to sign

--- a/src/shamap.js
+++ b/src/shamap.js
@@ -9,7 +9,8 @@ var HEX_ZERO = '00000000000000000000000000000000' +
 /**
  * Abstract class representing a node in a SHAMap tree.
  *
- * Can be either SHAMapTreeNodeInner or SHAMapTreeNodeLeaf.
+ * Can be either SHAMapTreeNodeInner, SHAMapTreeNodeInnerV2
+ * or SHAMapTreeNodeLeaf.
  *
  * @class
  */
@@ -122,6 +123,127 @@ SHAMapTreeNodeInner.prototype.hash = function() {
 };
 
 /**
+ * V2 inner (non-leaf) node in a SHAMap tree.
+ * @param {Number} depth ()
+ * @class
+ */
+function SHAMapTreeNodeInnerV2(depth) {
+  SHAMapTreeNodeInner.call(this, depth);
+  this.common = '';
+}
+
+util.inherits(SHAMapTreeNodeInnerV2, SHAMapTreeNodeInner);
+
+/**
+ * @param {String} key (equates to a ledger entry `index`)
+ * @return {Number} (common prefix depth)
+ */
+SHAMapTreeNodeInnerV2.prototype.get_common_prefix = function(key) {
+  var depth = 0;
+  for (var i = 0; i < this.depth; i++) {
+    if (this.common[i] === key[i]) {
+      depth++
+    }
+  }
+
+  return depth;
+};
+
+/**
+ * @param {String} key (equates to a ledger entry `index`)
+ * @return {bool} (returns true if common prefix exists)
+ */
+SHAMapTreeNodeInnerV2.prototype.has_common_prefix = function(key) {
+  for (var i = 0; i < this.depth; i++) {
+    if (this.common[i] !== key[i]) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+/**
+ * @param {String} tag (equates to a ledger entry `index`)
+ * @param {SHAMapTreeNode} node (to add)
+ * @return {void}
+ */
+SHAMapTreeNodeInnerV2.prototype.add_item = function(tag, node) {
+  var depth = this.depth;
+  var existing_node = this.get_node(tag[depth]);
+
+  if (existing_node) {
+    // A node already exists in this slot
+    if (existing_node instanceof SHAMapTreeNodeInnerV2) {
+      if (existing_node.has_common_prefix(tag)) {
+        // There is an inner node, so we need to go deeper
+        existing_node.add_item(tag, node);
+      } else {
+        // Create new inner node and move existing node under it
+        var new_depth = existing_node.get_common_prefix(tag);
+        var new_inner_node = new SHAMapTreeNodeInnerV2(new_depth);
+        new_inner_node.common = tag.slice(0, new_depth - 64);
+
+        // Parent new and existing node
+        new_inner_node.set_node(existing_node.common[new_depth], existing_node);
+        new_inner_node.add_item(tag, node);
+
+        // And place the newly created inner node in the slot
+        this.set_node(tag[depth], new_inner_node);
+      }
+    } else if (existing_node.tag === tag) {
+      // Collision
+      throw new Error(
+          'Tried to add a node to a SHAMap that was already in there.');
+    } else {
+      // Turn it into an inner node
+      var new_inner_node = new SHAMapTreeNodeInnerV2(0);
+
+      for (var i = 0; tag[i] === existing_node.tag[i]; i++) {
+        new_inner_node.common += tag[i];
+        new_inner_node.depth++;
+      }
+
+      // Parent new and existing node
+      new_inner_node.add_item(existing_node.tag, existing_node);
+      new_inner_node.add_item(tag, node);
+
+      // And place the newly created inner node in the slot
+      this.set_node(tag[depth], new_inner_node);
+    }
+  } else {
+    // Neat, we have a nice open spot for the new node
+    this.set_node(tag[depth], node);
+  }
+};
+
+SHAMapTreeNodeInnerV2.prototype.hash = function() {
+  if (this.empty) {
+    return HEX_ZERO;
+  }
+
+  var hex = '';
+  for (var i = 0; i < 16; i++) {
+    var slot = i.toString(16).toUpperCase();
+    hex += this.leaves[slot] ? this.leaves[slot].hash() : HEX_ZERO;
+  }
+
+  if (this.depth < 16) {
+    hex += '0';
+  }
+  hex += this.depth.toString(16).toUpperCase();
+
+  hex += this.common;
+  if (this.common.length % 2) {
+    hex += '0';
+  }
+
+  var prefix = hashprefixes.HASH_INNER_NODE_V2.toString(16);
+
+  return hash(prefix + hex);
+};
+
+/**
  * Leaf node in a SHAMap tree.
  * @param {String} tag (equates to a ledger entry `index`)
  * @param {String} data (hex of account state, transaction etc)
@@ -148,7 +270,8 @@ SHAMapTreeNodeLeaf.prototype.hash = function() {
       var leafPrefix = hashprefixes.HASH_LEAF_NODE.toString(16);
       return hash(leafPrefix + this.data + this.tag);
     case SHAMapTreeNode.TYPE_TRANSACTION_NM:
-      return this.tag;
+      var txPrefix = hashprefixes.HASH_TX_ID.toString(16);
+      return hash(txPrefix + this.data);
     case SHAMapTreeNode.TYPE_TRANSACTION_MD:
       var txPrefix = hashprefixes.HASH_TX_NODE.toString(16);
       return hash(txPrefix + this.data + this.tag);
@@ -157,8 +280,15 @@ SHAMapTreeNodeLeaf.prototype.hash = function() {
   }
 };
 
-function SHAMap() {
-  this.root = new SHAMapTreeNodeInner(0);
+/**
+ * SHAMap tree.
+ * @param {Number} version (inner node version number)
+ * @class
+ */
+function SHAMap(version) {
+  this.version = version === undefined ? 1 : version;
+  this.root = this.version === 1 ? new SHAMapTreeNodeInner(0) :
+    new SHAMapTreeNodeInnerV2(0);
 }
 
 SHAMap.prototype.add_item = function(tag, data, type) {
@@ -172,4 +302,5 @@ SHAMap.prototype.hash = function() {
 exports.SHAMap = SHAMap;
 exports.SHAMapTreeNode = SHAMapTreeNode;
 exports.SHAMapTreeNodeInner = SHAMapTreeNodeInner;
+exports.SHAMapTreeNodeInnerV2 = SHAMapTreeNodeInnerV2;
 exports.SHAMapTreeNodeLeaf = SHAMapTreeNodeLeaf;

--- a/test/shamap-test.js
+++ b/test/shamap-test.js
@@ -1,0 +1,83 @@
+/* eslint-disable max-len, valid-jsdoc */
+'use strict';
+
+var assert = require('assert');
+var SHAMap = require('../src/shamap').SHAMap;
+var SHAMapTreeNode = require('../src/shamap').SHAMapTreeNode;
+
+var HEX_ZERO = '00000000000000000000000000000000' +
+               '00000000000000000000000000000000';
+
+function int_to_vuc(v) {
+  var ret = '';
+
+  for (var i = 0; i < 32; i++) {
+    ret += '0';
+    ret += v.toString(16).toUpperCase();
+  }
+  return ret;
+}
+
+/**
+* @param shamap {Object}
+* @param keys {Array}
+* @param hashes {Array}
+*/
+function fill_shamap_test(shamap, keys, hashes) {
+  for (var i = 0; i < keys.length; i++) {
+    var data = int_to_vuc(i);
+    shamap.add_item(keys[i].toUpperCase(), data, SHAMapTreeNode.TYPE_TRANSACTION_NM);
+    assert.equal(shamap.hash(), hashes[i]);
+  }
+}
+
+describe('SHAMap', function() {
+
+  describe('#add_item', function() {
+    it('will add new nodes to v1 or v2 tree', function() {
+      var keys = [
+        'b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8',
+        'b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8',
+        'b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8',
+        'b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8',
+        'b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8',
+        'b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8',
+        'f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8',
+        '292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8'
+      ];
+
+      var hashesv1 = [
+        'B7387CFEA0465759ADC718E8C42B52D2309D179B326E239EB5075C64B6281F7F',
+        'FBC195A9592A54AB44010274163CB6BA95F497EC5BA0A8831845467FB2ECE266',
+        '4E7D2684B65DFD48937FFB775E20175C43AF0C94066F7D5679F51AE756795B75',
+        '7A2F312EB203695FFD164E038E281839EEF06A1B99BFC263F3CECC6C74F93E07',
+        '395A6691A372387A703FB0F2C6D2C405DAF307D0817F8F0E207596462B0E3A3E',
+        'D044C0A696DE3169CC70AE216A1564D69DE96582865796142CE7D98A84D9DDE4',
+        '76DCC77C4027309B5A91AD164083264D70B77B5E43E08AEDA5EBF94361143615',
+        'DF4220E93ADC6F5569063A01B4DC79F8DB9553B6A3222ADE23DEA02BBE7230E5'
+      ];
+
+
+      var shamapv1 = new SHAMap();
+      assert.equal(shamapv1.hash(), HEX_ZERO);
+      fill_shamap_test(shamapv1, keys, hashesv1);
+
+      var hashesv2 = [
+        '90F77DA53895E34042DC8048518CC98AD24276D0A96CCA2C515A83FDAF9F9FC9',
+        '425A3B6A68FAD9CB43B9981C7D0D39B942FE62110B437201057EE703F5E76390',
+        '1B4BE72DD18F90F367D64C0147D2414329149724339F79958D6470E7C99E3F4A',
+        'CCC18ED9B0C353278F02465E2E2F3A8A07427B458CF74C51D87ABE9C1B2ECAD8',
+        '24AF98675227F387CE0E4932B71B099FE8BC66E5F07BE2DA70D7E7D98E16C8BC',
+        'EAA373271474A9BF18F1CC240B40C7B5C83C7017977F1388771E56D5943F2B9B',
+        'C7968A323A06BD46769B402B2A85A7FE7F37FCE99C0004A6197AD8E5D76F200D',
+        '0A2412DBB16308706211E5FA5B0160817D54757B4DDC0CB105391A79D06B47BA'
+      ];
+
+      var shamapv2 = new SHAMap(2);
+      assert.equal(shamapv2.hash(), HEX_ZERO);
+      fill_shamap_test(shamapv2, keys, hashesv2);
+    });
+  });
+});
+
+// vim:sw=2:sts=2:ts=8:et


### PR DESCRIPTION
SHAMapV2 excludes single child nodes. Inner nodes include the shared common prefix of all child nodes.
https://ripple.com/build/amendments/#shamapv2

The test is modeled after those in rippled
https://github.com/ripple/rippled/blob/9e960ff6b89cd303fbc393f3ecb0bda19ffca92e/src/test/shamap/SHAMap_test.cpp#L214-L259